### PR TITLE
Add header login/signup modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "tailwindcss": "^3.4.1",
     "web-vitals": "^2.1.4"
   },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/App.css
+++ b/src/App.css
@@ -109,21 +109,19 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   background: #2980b9;
 }
-.login-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  padding: 20px;
-}
-
-.login-form {
+.auth-modal {
   background: white;
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 400px;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .form-group {

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,6 @@ import ServiceProviders from './pages/ServiceProviders';
 import ProviderProfile from './pages/ProviderProfile';
 import Contact from './pages/Contact';
 import About from './pages/About';
-import Auth from './pages/Auth';
 import CustomerProfile from './pages/CustomerProfile';
 import './App.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
@@ -21,7 +20,7 @@ const ProtectedRoute = ({ children }) => {
   const location = useLocation();
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" state={{ from: location }} replace />;
+    return <Navigate to="/" state={{ from: location }} replace />;
   }
 
   return children;
@@ -59,17 +58,8 @@ function App() {
           <Header />
           <main className="main-content">
             <Routes>
-              <Route path="/auth" element={<Auth />} />
-              <Route path="/" element={
-                <ProtectedRoute>
-                  <Home />
-                </ProtectedRoute>
-              } />
-              <Route path="/services" element={
-                <ProtectedRoute>
-                  <Services />
-                </ProtectedRoute>
-              } />
+              <Route path="/" element={<Home />} />
+              <Route path="/services" element={<Services />} />
               <Route path="/service-providers/:serviceId" element={
                 <ProtectedRoute>
                   <ServiceProviders />

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,254 +1,120 @@
-.footer {
-  background: #1a1a1a;
-  color: #ffffff;
-  padding: var(--spacing-unit) 0;
-  margin-top: auto;
+.yelp-footer {
+  background: #f8f8f8;
+  font-family: Helvetica, Arial, sans-serif;
+  color: #333;
+  padding: 40px 20px;
+  font-size: 14px;
 }
 
-.footer-content {
-  max-width: var(--max-width);
+.footer-top {
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 0 var(--spacing-unit);
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: clamp(1rem, 2vw, 2rem);
 }
 
-.footer-section {
-  padding: clamp(1rem, 2vw, 1.5rem) 0;
-}
-
-.footer-section h3 {
-  color: #ffffff;
-  font-size: clamp(1rem, 2vw, 1.2rem);
-  font-weight: 600;
-  margin-bottom: clamp(0.75rem, 2vw, 1.5rem);
-  letter-spacing: 0.5px;
-}
-
-.footer-section p {
-  color: #b3b3b3;
-  line-height: 1.6;
-  margin-bottom: clamp(0.75rem, 2vw, 1.5rem);
-  font-size: clamp(0.8rem, 2vw, 0.95rem);
-}
-.footer-bottom{
+.footer-columns {
   display: flex;
-  justify-content: center;
-}
-/* Social Links */
-.social-links {
-  display: flex;
-  gap: clamp(0.5rem, 2vw, 1rem);
-  margin-top: clamp(0.5rem, 2vw, 1rem);
   flex-wrap: wrap;
+  gap: 40px;
 }
 
-.social-link {
-  background: #ffffff;
-  color: #1a1a1a;
-  width: clamp(30px, 5vw, 40px);
-  height: clamp(30px, 5vw, 40px);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  transition: all 0.3s ease;
-  font-size: clamp(0.8rem, 2vw, 1.2rem);
+.footer-col {
+  flex: 1 1 200px;
+  min-width: 160px;
 }
 
-.social-link:hover {
-  background: #3498db;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(52, 152, 219, 0.3);
+.footer-col h3 {
+  font-size: 16px;
+  margin-bottom: 12px;
+  color: #333;
 }
 
-/* Footer Links */
-.footer-links {
+.footer-col ul {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.footer-links li {
-  margin-bottom: clamp(0.5rem, 2vw, 0.75rem);
+.footer-col li {
+  margin-bottom: 8px;
 }
 
-.footer-links a {
-  color: #b3b3b3;
+.footer-col a {
+  color: #555;
   text-decoration: none;
-  transition: color 0.3s ease;
-  font-size: clamp(0.75rem, 2vw, 0.9rem);
 }
 
-.footer-links a:hover {
-  color: #ffffff;
+.footer-col a:hover {
+  text-decoration: underline;
 }
 
-/* Contact Info */
-.contact-info {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(0.5rem, 2vw, 1rem);
+.footer-right .footer-lang,
+.footer-right .footer-cities {
+  margin-bottom: 20px;
 }
 
-.contact-item {
-  display: flex;
-  align-items: center;
-  gap: clamp(0.5rem, 2vw, 0.75rem);
+.footer-right a {
+  color: #555;
+  text-decoration: none;
 }
 
-.contact-item i {
-  color: #3498db;
-  font-size: clamp(0.8rem, 2vw, 1.2rem);
+.footer-right a:hover {
+  text-decoration: underline;
 }
 
-.contact-item span {
-  color: #b3b3b3;
-  font-size: clamp(0.75rem, 2vw, 0.9rem);
-}
-
-/* Newsletter Form */
-.newsletter-form {
-  display: flex;
-  gap: clamp(0.5rem, 2vw, 1rem);
-  flex-wrap: wrap;
-}
-
-.newsletter-input {
-  flex: 1;
-  padding: clamp(0.5rem, 2vw, 0.75rem);
+.dropdown-toggle {
+  background: none;
   border: none;
-  border-radius: 4px;
-  background: #2a2a2a;
-  color: #ffffff;
-  font-size: clamp(0.75rem, 2vw, 0.9rem);
-}
-
-.newsletter-button {
-  padding: clamp(0.5rem, 2vw, 0.75rem) clamp(1rem, 2vw, 1.5rem);
-  background: #3498db;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
+  padding: 0;
+  font: inherit;
+  color: #555;
   cursor: pointer;
-  font-size: clamp(0.75rem, 2vw, 0.9rem);
-  transition: background-color 0.3s ease;
 }
 
-.newsletter-button:hover {
-  background: #2980b9;
+.dropdown-toggle:hover {
+  text-decoration: underline;
 }
 
-/* Responsive Adjustments */
+.cities-dropdown {
+  list-style: none;
+  padding: 8px 0 0;
+  margin: 0;
+}
+
+.cities-dropdown li {
+  margin-bottom: 4px;
+}
+
+.cities-dropdown a {
+  color: #555;
+  text-decoration: none;
+}
+
+.cities-dropdown a:hover {
+  text-decoration: underline;
+}
+
+.caret {
+  margin-left: 4px;
+}
+
+.footer-bottom {
+  border-top: 1px solid #e6e6e6;
+  margin-top: 30px;
+  padding-top: 20px;
+  text-align: center;
+  color: #777;
+  font-size: 13px;
+}
+
 @media (max-width: 768px) {
-  .footer {
-    padding: 2rem 0 1rem;
-  }
-
-  .footer-content {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .social-links {
-    justify-content: center;
-  }
-
-  .newsletter-form {
-    flex-direction: column;
-  }
-
-  .newsletter-input {
-    margin-bottom: 0.5rem;
+  .footer-col {
+    flex: 1 1 50%;
+    margin-bottom: 20px;
   }
 }
 
 @media (max-width: 480px) {
-  .footer {
-    padding: 1.5rem 0 0.5rem;
-  }
-
-  .footer-content {
-    padding: 0.5rem;
-  }
-
-  .footer-section h3 {
-    font-size: 1.1rem;
-  }
-
-  .footer-section p {
-    font-size: 0.85rem;
-    line-height: 1.4;
-  }
-
-  .social-link {
-    width: 35px;
-    height: 35px;
-    font-size: 1rem;
-  }
-
-  .contact-item i {
-    font-size: 1rem;
-  }
-
-  .contact-item span {
-    font-size: 0.85rem;
-  }
-
-  .newsletter-input,
-  .newsletter-button {
-    width: 100%;
-    padding: 0.5rem;
-  }
-}
-
-/* Accessibility */
-.footer-section:focus-within {
-  outline: 2px solid #3498db;
-  outline-offset: 2px;
-}
-
-.newsletter-input:focus {
-  outline: 2px solid #3498db;
-  outline-offset: 2px;
-}
-
-.newsletter-button:focus {
-  outline: 2px solid #3498db;
-  outline-offset: 2px;
-}
-
-/* Copyright Section */
-.copyright-section {
-  background: #151515;
-  padding: clamp(1rem, 2vw, 1.5rem);
-  text-align: center;
-  font-size: clamp(0.75rem, 2vw, 0.9rem);
-  color: #b3b3b3;
-  margin-top: clamp(1rem, 2vw, 2rem);
-}
-
-/* Loading State */
-.footer.loading {
-  opacity: 0.8;
-}
-
-.footer.loading::after {
-  content: '';
-  display: block;
-  width: 100%;
-  height: 3px;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
-  animation: shimmer 1.5s infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -1000px 0;
-  }
-  100% {
-    background-position: 1000px 0;
+  .footer-col {
+    flex: 1 1 100%;
   }
 }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,90 +1,94 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './Footer.css';
-import { Link } from 'react-router-dom';
+
 const Footer = () => {
+  const [showCities, setShowCities] = useState(false);
+
+  const toggleCities = (e) => {
+    e.preventDefault();
+    setShowCities((prev) => !prev);
+  };
   return (
-    <footer className="footer">
-      <div className="footer-content">
-        <div className="footer-section">
-          <h3>About Us</h3>
-          <p>AAA Services Directory is your one-stop platform for discovering and booking professional services across various categories.</p>
-          {/* <div className="social-links">
-            <a href="/" className="social-link">
-              <i className="fab fa-facebook"></i>
-            </a>
-            <a href="/" className="social-link">
-              <i className="fab fa-twitter"></i>
-            </a>
-            <a href="/" className="social-link">
-              <i className="fab fa-instagram"></i>
-            </a>
-            <a href="/" className="social-link">
-              <i className="fab fa-linkedin"></i>
-            </a>
-          </div> */}
-           <div className="nav-links">
-                      <Link to="/" className="nav-link"><i className="fab fa-facebook"></i></Link>
-                      <Link to="/" className="nav-link"><i className="fab fa-twitter"></i></Link>
-                      <Link to="/" className="nav-link"><i className="fab fa-instagram"></i></Link>
-                      <Link to="/" className="nav-link"><i className="fab fa-linkedin"></i></Link>
-                    </div>
-        </div>
-
-        <div className="footer-section">
-          <h3>Quick Links</h3>
-          <ul className="footer-links">
-             <li><Link to="/" className="nav-link">Home</Link> </li> 
-             <li><Link to="/services" className="nav-link">Services</Link> </li> 
-             <li><Link to="/about" className="nav-link">About Us</Link> </li> 
-             <li><Link to="/contact" className="nav-link">Contact</Link> </li> 
-            {/* <li><a href="#privacy">Privacy Policy</a></li>
-            <li><a href="#terms">Terms & Conditions</a></li> */}
-          </ul>
-        </div>
-
-        <div className="footer-section">
-          <h3>Contact Us</h3>
-          <div className="contact-info">
-            <div className="contact-item">
-              <i className="fas fa-map-marker-alt"></i>
-              <span>Township, Lahore,Pakistan.</span>
+    <footer className="yelp-footer">
+      <div className="footer-top">
+        <div className="footer-columns">
+          <div className="footer-col">
+            <h3>About</h3>
+            <ul>
+              <li><a href="/about">About AAA</a></li>
+              <li><a href="/careers">Careers</a></li>
+              <li><a href="/press">Press</a></li>
+              <li><a href="/investor-relations">Investor Relations</a></li>
+              <li><a href="/trust-safety">Trust &amp; Safety</a></li>
+              <li><a href="/content-guidelines">Content Guidelines</a></li>
+              <li><a href="/accessibility">Accessibility Statement</a></li>
+              <li><a href="/terms-of-service">Terms of Service</a></li>
+              <li><a href="/privacy-policy">Privacy Policy</a></li>
+              <li><a href="/ad-choices">Ad Choices</a></li>
+              <li><a href="/privacy-choices">Your Privacy Choices</a></li>
+            </ul>
+          </div>
+          <div className="footer-col">
+            <h3>Discover</h3>
+            <ul>
+              <li><a href="/project-cost-guides">AAA Project Cost Guides</a></li>
+              <li><a href="/collections">Collections</a></li>
+              <li><a href="/talk">Talk</a></li>
+              <li><a href="/events">Events</a></li>
+              <li><a href="/blog">AAA Blog</a></li>
+              <li><a href="/support">Support</a></li>
+              <li><a href="/mobile">AAA Mobile</a></li>
+              <li><a href="/developers">Developers</a></li>
+              <li><a href="/rss">RSS</a></li>
+            </ul>
+          </div>
+          <div className="footer-col">
+            <h3>AAA for Business</h3>
+            <ul>
+              <li><a href="/business">AAA for Business</a></li>
+              <li><a href="/business/login">Business Owner Login</a></li>
+              <li><a href="/claim-business">Claim your Business Page</a></li>
+              <li><a href="/advertise">Advertise on AAA</a></li>
+              <li><a href="/restaurant-owners">AAA for Restaurant Owners</a></li>
+              <li><a href="/table-management">Table Management</a></li>
+              <li><a href="/success-stories">Business Success Stories</a></li>
+              <li><a href="/business-support">Business Support</a></li>
+              <li><a href="/biz-blog">AAA Blog for Business</a></li>
+              <li><a href="/data-b2b">AAA Data for B2B</a></li>
+              <li><a href="/data-b2c">AAA Data for B2C</a></li>
+            </ul>
+          </div>
+          <div className="footer-col footer-right">
+            <div className="footer-lang">
+              <h3>Languages</h3>
+              <a href="/change-language">English <span className="caret">▼</span></a>
             </div>
-            <div className="contact-item">
-              <i className="fas fa-phone"></i>
-              <span>0308-6613608</span>
-            </div>
-            <div className="contact-item">
-              <i className="fas fa-envelope"></i>
-              <span>haider.2002.786@gmail.com</span>
+            <div className="footer-cities">
+              <h3>Cities</h3>
+              <button type="button" className="dropdown-toggle" onClick={toggleCities}>
+                Explore a City <span className="caret">▼</span>
+              </button>
+              {showCities && (
+                <ul className="cities-dropdown">
+                  <li><a href="/cities/karachi">Karachi</a></li>
+                  <li><a href="/cities/lahore">Lahore</a></li>
+                  <li><a href="/cities/islamabad">Islamabad</a></li>
+                  <li><a href="/cities/rawalpindi">Rawalpindi</a></li>
+                  <li><a href="/cities/faisalabad">Faisalabad</a></li>
+                  <li><a href="/cities/multan">Multan</a></li>
+                  <li><a href="/cities/peshawar">Peshawar</a></li>
+                  <li><a href="/cities/quetta">Quetta</a></li>
+                </ul>
+              )}
             </div>
           </div>
-        </div>
-
-        <div className="footer-section">
-          <h3>Newsletter</h3>
-          <p>Subscribe to our newsletter for latest updates and offers.</p>
-          <form className="newsletter-form">
-            <input type="email" placeholder="Enter your email" required />
-            <button type="submit">Subscribe</button>
-          </form>
         </div>
       </div>
-
       <div className="footer-bottom">
-        <div className="footer-bottom-content">
-          <div className="footer-logo">
-            <span className="logo-text">AAA</span>
-            <span className="logo-subtitle">Services Directory</span>
-          </div>
-          <div className="footer-copyright">
-            <p>&copy; {new Date().getFullYear()} AAA Services Directory. All rights reserved.</p>
-            <div className="footer-links">
-              <a href="#privacy">Privacy Policy</a>
-              <span>|</span>
-              <a href="#terms">Terms & Conditions</a>
-            </div>
-          </div>
-        </div>
+        <p>
+          Copyright © 2004–2025 AAA Inc. AAA, Elite Squad, and related marks are
+          registered trademarks of AAA.
+        </p>
       </div>
     </footer>
   );

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,111 +1,207 @@
 import React, { useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../App';
+import Login from '../pages/Login';
+import Signup from '../pages/Signup';
+
+const categories = [
+  { icon: 'utensils', label: 'Restaurants' },
+  { icon: 'truck', label: 'Delivery' },
+  { icon: 'shopping-bag', label: 'Takeout' },
+  { icon: 'calculator', label: 'Accountants' },
+  { icon: 'wrench', label: 'Plumbers' },
+  { icon: 'car', label: 'Auto Repair' },
+];
 
 const Header = () => {
   const [searchTerm, setSearchTerm] = useState('');
-  const [location, setLocation] = useState('');
-  const { isAuthenticated, user } = useContext(AuthContext);
+  const [searchLocation, setSearchLocation] = useState('');
+  const [showLogin, setShowLogin] = useState(false);
+  const [showSignup, setShowSignup] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const { isAuthenticated } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const handleSearch = (e) => {
     e.preventDefault();
-    navigate(`/search?q=${searchTerm}&location=${location}`);
+    setSearchOpen(false);
+    navigate(`/search?q=${searchTerm}&location=${searchLocation}`);
   };
 
   return (
-    <header className="bg-white border-b border-gray-200">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
-          {/* Logo */}
-          <Link to="/" className="flex-shrink-0">
-            <img src="/AAA.jpeg" alt="Logo" className="h-8 w-auto" />
-          </Link>
+    <header className="sticky top-0 z-50">
+      {/* Mobile Header */}
+      <div className="md:hidden">
+        <div className="flex items-center justify-between bg-yelp-red text-white px-3 py-2">
+          <button className="text-sm font-medium">Open in App</button>
+          <img src="/AAA.jpeg" alt="AAA logo" className="h-6" />
+          <button aria-label="Menu" onClick={() => setMenuOpen(true)}>
+            <i className="fas fa-bars text-xl"></i>
+          </button>
+        </div>
+        <div className="bg-white border-b px-3 py-2">
+          <input
+            type="text"
+            placeholder="e.g. tacos, Mel's"
+            className="w-full border rounded px-3 py-2"
+            onFocus={() => setSearchOpen(true)}
+            readOnly
+          />
+        </div>
+      </div>
 
-          {/* Search Form */}
-          <form onSubmit={handleSearch} className="flex-1 max-w-3xl mx-8">
-            <div className="flex shadow-sm">
-              <input
-                type="text"
-                placeholder="Search for services..."
-                className="flex-1 px-4 py-2 border-2 border-r-0 border-gray-300 focus:ring-red-500 focus:border-red-500 rounded-l-md"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-              <input
-                type="text"
-                placeholder="Location"
-                className="flex-1 px-4 py-2 border-2 border-gray-300 focus:ring-red-500 focus:border-red-500"
-                value={location}
-                onChange={(e) => setLocation(e.target.value)}
-              />
-              <button
-                type="submit"
-                className="px-6 py-2 bg-red-600 text-white font-medium rounded-r-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
-              >
-                <i className="fas fa-search"></i>
+      {/* Desktop Header */}
+      <div className="hidden md:block bg-white border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link to="/" className="flex-shrink-0">
+              <img src="/AAA.jpeg" alt="Logo" className="h-8 w-auto" />
+            </Link>
+            <form onSubmit={handleSearch} className="flex-1 max-w-3xl mx-8">
+              <div className="flex shadow-sm">
+                <input
+                  type="text"
+                  placeholder="Search for services..."
+                  className="flex-1 px-4 py-2 border-2 border-r-0 border-gray-300 focus:ring-red-500 focus:border-red-500 rounded-l-md"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+                <input
+                  type="text"
+                  placeholder="Location"
+                  className="flex-1 px-4 py-2 border-2 border-gray-300 focus:ring-red-500 focus:border-red-500"
+                  value={searchLocation}
+                  onChange={(e) => setSearchLocation(e.target.value)}
+                />
+                <button
+                  type="submit"
+                  className="px-6 py-2 bg-red-600 text-white font-medium rounded-r-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+                >
+                  <i className="fas fa-search"></i>
+                </button>
+              </div>
+            </form>
+            <div className="flex items-center space-x-4">
+              {isAuthenticated ? (
+                <>
+                  <Link to="/messages" className="text-gray-600 hover:text-red-600">
+                    <i className="fas fa-envelope text-xl"></i>
+                  </Link>
+                  <Link to="/notifications" className="text-gray-600 hover:text-red-600">
+                    <i className="fas fa-bell text-xl"></i>
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <button onClick={() => setShowLogin(true)} className="text-gray-600 hover:text-red-600 font-medium">
+                    Log In
+                  </button>
+                  <button
+                    onClick={() => setShowSignup(true)}
+                    className="px-4 py-2 bg-red-600 text-white font-medium rounded-md hover:bg-red-700"
+                  >
+                    Sign Up
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+          <nav className="flex space-x-8 py-3">
+            <Link to="/restaurants" className="text-gray-600 hover:text-red-600">Restaurants</Link>
+            <Link to="/home-services" className="text-gray-600 hover:text-red-600">Home Services</Link>
+            <Link to="/auto-services" className="text-gray-600 hover:text-red-600">Auto Services</Link>
+            <Link to="/health" className="text-gray-600 hover:text-red-600">Health &amp; Beauty</Link>
+            <Link to="/travel" className="text-gray-600 hover:text-red-600">Travel &amp; Activities</Link>
+          </nav>
+        </div>
+      </div>
+
+      {showLogin && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+          <Login
+            onClose={() => setShowLogin(false)}
+            onSwitchToSignup={() => {
+              setShowLogin(false);
+              setShowSignup(true);
+            }}
+          />
+        </div>
+      )}
+
+      {showSignup && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+          <Signup
+            onClose={() => setShowSignup(false)}
+            onSwitchToLogin={() => {
+              setShowSignup(false);
+              setShowLogin(true);
+            }}
+          />
+        </div>
+      )}
+
+      {searchOpen && (
+        <div className="fixed inset-0 bg-white z-50 overflow-y-auto">
+          <div className="flex items-center justify-between bg-yelp-red text-white px-4 py-3 sticky top-0">
+            <button onClick={() => setSearchOpen(false)}>Cancel</button>
+            <span className="font-semibold">Search</span>
+          </div>
+          <form onSubmit={handleSearch} className="p-4 space-y-4">
+            <input
+              type="text"
+              className="w-full border rounded px-3 py-2"
+              placeholder="e.g. plumber, electrician"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+            <input
+              type="text"
+              className="w-full border rounded px-3 py-2"
+              placeholder="Lahore, Pakistan 54700"
+              value={searchLocation}
+              onChange={(e) => setSearchLocation(e.target.value)}
+            />
+            <ul className="divide-y mt-4">
+              {categories.map((c) => (
+                <li key={c.label} className="flex items-center py-3 space-x-2">
+                  <i className={`fas fa-${c.icon} w-5 text-gray-600`}></i>
+                  <span>{c.label}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4 flex justify-end">
+              <button type="submit" className="px-4 py-2 bg-yelp-red text-white rounded">
+                Search
               </button>
             </div>
           </form>
-
-          {/* Auth Buttons */}
-          <div className="flex items-center space-x-4">
-            {isAuthenticated ? (
-              <div className="flex items-center space-x-4">
-                <Link to="/messages\" className="text-gray-600 hover:text-red-600">
-                  <i className="fas fa-envelope text-xl"></i>
-                </Link>
-                <Link to="/notifications" className="text-gray-600 hover:text-red-600">
-                  <i className="fas fa-bell text-xl"></i>
-                </Link>
-                <div className="relative group">
-                  <button className="flex items-center space-x-2 text-gray-600 hover:text-red-600">
-                    <img
-                      src={user?.photoURL || "https://via.placeholder.com/32"}
-                      alt="Profile"
-                      className="h-8 w-8 rounded-full"
-                    />
-                    <i className="fas fa-chevron-down"></i>
-                  </button>
-                  <div className="absolute right-0 w-48 mt-2 bg-white rounded-md shadow-lg hidden group-hover:block">
-                    <Link to="/profile" className="block px-4 py-2 text-gray-700 hover:bg-gray-100">Profile</Link>
-                    <Link to="/settings" className="block px-4 py-2 text-gray-700 hover:bg-gray-100">Settings</Link>
-                    <button className="block w-full text-left px-4 py-2 text-gray-700 hover:bg-gray-100">Sign Out</button>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <>
-                <Link to="/login" className="text-gray-600 hover:text-red-600 font-medium">
-                  Log In
-                </Link>
-                <Link to="/signup" className="px-4 py-2 bg-red-600 text-white font-medium rounded-md hover:bg-red-700">
-                  Sign Up
-                </Link>
-              </>
-            )}
-          </div>
         </div>
+      )}
 
-        {/* Navigation */}
-        <nav className="flex space-x-8 py-3">
-          <Link to="/restaurants" className="text-gray-600 hover:text-red-600">Restaurants</Link>
-          <Link to="/home-services" className="text-gray-600 hover:text-red-600">Home Services</Link>
-          <Link to="/auto-services" className="text-gray-600 hover:text-red-600">Auto Services</Link>
-          <Link to="/health" className="text-gray-600 hover:text-red-600">Health & Beauty</Link>
-          <Link to="/travel" className="text-gray-600 hover:text-red-600">Travel & Activities</Link>
-          <div className="relative group">
-            <button className="text-gray-600 hover:text-red-600 flex items-center">
-              More <i className="fas fa-chevron-down ml-1"></i>
-            </button>
-            <div className="absolute left-0 mt-2 w-48 bg-white rounded-md shadow-lg hidden group-hover:block">
-              <Link to="/shopping" className="block px-4 py-2 text-gray-700 hover:bg-gray-100">Shopping</Link>
-              <Link to="/nightlife" className="block px-4 py-2 text-gray-700 hover:bg-gray-100">Nightlife</Link>
-              <Link to="/events" className="block px-4 py-2 text-gray-700 hover:bg-gray-100">Events</Link>
+      {menuOpen && (
+        <div className="fixed inset-0 z-50">
+          <div className="absolute inset-0 bg-black bg-opacity-50" onClick={() => setMenuOpen(false)}></div>
+          <div className="absolute inset-0 bg-white flex flex-col">
+            <div className="flex items-center justify-between bg-yelp-red text-white px-4 py-3">
+              <img src="/AAA.jpeg" alt="AAA logo" className="h-6 mx-auto" />
+              <button aria-label="Close" onClick={() => setMenuOpen(false)} className="text-2xl">✕</button>
+            </div>
+            <div className="flex flex-col p-4 space-y-4">
+              <button onClick={() => { setMenuOpen(false); setShowSignup(true); }} className="text-left font-medium">Sign Up</button>
+              <button onClick={() => { setMenuOpen(false); setShowLogin(true); }} className="text-left font-medium">Log In</button>
+              <Link to="/nearby" onClick={() => setMenuOpen(false)} className="text-left">Nearby</Link>
+              <Link to="/bookmarks" onClick={() => setMenuOpen(false)} className="text-left">Bookmarks</Link>
+              <Link to="/start-project" onClick={() => setMenuOpen(false)} className="text-left">Start a Project</Link>
+              <Link to="/add-business" onClick={() => setMenuOpen(false)} className="text-left">Add a Business on AAA</Link>
+            </div>
+            <div className="mt-auto p-4 text-sm text-center text-gray-500 border-t">
+              <a href="#" className="mr-2">Ad Choices</a>
+              <a href="#">Support</a>
             </div>
           </div>
-        </nav>
-      </div>
+        </div>
+      )}
     </header>
   );
 };

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -196,8 +196,8 @@ const Header = () => {
               <Link to="/add-business" onClick={() => setMenuOpen(false)} className="text-left">Add a Business on AAA</Link>
             </div>
             <div className="mt-auto p-4 text-sm text-center text-gray-500 border-t">
-              <a href="#" className="mr-2">Ad Choices</a>
-              <a href="#">Support</a>
+              <Link to="/ad-choices" className="mr-2">Ad Choices</Link>
+              <Link to="/support">Support</Link>
             </div>
           </div>
         </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -20,6 +20,7 @@ const Header = () => {
   const [showSignup, setShowSignup] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
   const { isAuthenticated } = useContext(AuthContext);
   const navigate = useNavigate();
 
@@ -27,6 +28,18 @@ const Header = () => {
     e.preventDefault();
     setSearchOpen(false);
     navigate(`/search?q=${searchTerm}&location=${searchLocation}`);
+  };
+
+  const detectLocation = () => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const { latitude, longitude } = pos.coords;
+          setSearchLocation(`${latitude.toFixed(5)}, ${longitude.toFixed(5)}`);
+        },
+        () => {}
+      );
+    }
   };
 
   return (
@@ -59,20 +72,44 @@ const Header = () => {
               <img src="/AAA.jpeg" alt="Logo" className="h-8 w-auto" />
             </Link>
             <form onSubmit={handleSearch} className="flex-1 max-w-3xl mx-8">
-              <div className="flex shadow-sm">
-                <input
-                  type="text"
-                  placeholder="Search for services..."
-                  className="flex-1 px-4 py-2 border-2 border-r-0 border-gray-300 focus:ring-red-500 focus:border-red-500 rounded-l-md"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
+              <div className="flex shadow-sm relative">
+                <div className="flex-1 relative">
+                  <input
+                    type="text"
+                    placeholder="Search for services..."
+                    className="w-full px-4 py-2 border-2 border-r-0 border-gray-300 focus:ring-red-500 focus:border-red-500 rounded-l-md"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    onFocus={() => setShowSuggestions(true)}
+                    onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
+                  />
+                  {showSuggestions && (
+                    <ul className="absolute left-0 right-0 bg-white border border-gray-300 rounded-b-md top-full z-10 max-h-48 overflow-y-auto">
+                      {categories.map((c) => (
+                        <li
+                          key={c.label}
+                          className="px-3 py-2 hover:bg-gray-100 cursor-pointer flex items-center"
+                          onMouseDown={() => {
+                            setSearchTerm(c.label);
+                            setShowSuggestions(false);
+                          }}
+                        >
+                          <i className={`fas fa-${c.icon} w-4 mr-2`}></i>
+                          {c.label}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
                 <input
                   type="text"
                   placeholder="Location"
                   className="flex-1 px-4 py-2 border-2 border-gray-300 focus:ring-red-500 focus:border-red-500"
                   value={searchLocation}
                   onChange={(e) => setSearchLocation(e.target.value)}
+                  onFocus={() => {
+                    if (!searchLocation) detectLocation();
+                  }}
                 />
                 <button
                   type="submit"
@@ -161,10 +198,17 @@ const Header = () => {
               placeholder="Lahore, Pakistan 54700"
               value={searchLocation}
               onChange={(e) => setSearchLocation(e.target.value)}
+              onFocus={() => {
+                if (!searchLocation) detectLocation();
+              }}
             />
             <ul className="divide-y mt-4">
               {categories.map((c) => (
-                <li key={c.label} className="flex items-center py-3 space-x-2">
+                <li
+                  key={c.label}
+                  className="flex items-center py-3 space-x-2 cursor-pointer"
+                  onMouseDown={() => setSearchTerm(c.label)}
+                >
                   <i className={`fas fa-${c.icon} w-5 text-gray-600`}></i>
                   <span>{c.label}</span>
                 </li>

--- a/src/pages/Auth.css
+++ b/src/pages/Auth.css
@@ -120,3 +120,18 @@
   font-size: 0.9rem;
   margin-top: 0.5rem;
 }
+
+.progress-container {
+  height: 4px;
+  background: #e0e0e0;
+  margin-bottom: 1rem;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  background: #3498db;
+  width: 0;
+  transition: width 0.3s ease;
+}

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,34 +1,90 @@
 import React, { useState, useContext } from 'react';
 import { AuthContext } from '../App';
 import { useNavigate } from 'react-router-dom';
+import { auth, googleProvider, facebookProvider } from '../firebase';
+import { signInWithEmailAndPassword, signInWithPopup } from 'firebase/auth';
 
-function Login() {
-  const [username, setUsername] = useState('');
+function Login({ onClose, onSwitchToSignup }) {
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const { login } = useContext(AuthContext);
+  const { setIsAuthenticated, setUser } = useContext(AuthContext);
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (login(username, password)) {
+    setError('');
+    try {
+      const cred = await signInWithEmailAndPassword(auth, email, password);
+      const userData = {
+        email: cred.user.email,
+        uid: cred.user.uid,
+        displayName: cred.user.displayName
+      };
+      localStorage.setItem('user', JSON.stringify(userData));
+      setUser(userData);
+      setIsAuthenticated(true);
       navigate('/');
-    } else {
+    } catch (err) {
       setError('Invalid credentials');
     }
   };
 
+  const handleGoogleSignIn = async () => {
+    try {
+      const cred = await signInWithPopup(auth, googleProvider);
+      const userData = {
+        email: cred.user.email,
+        uid: cred.user.uid,
+        displayName: cred.user.displayName
+      };
+      localStorage.setItem('user', JSON.stringify(userData));
+      setUser(userData);
+      setIsAuthenticated(true);
+      navigate('/');
+    } catch (err) {
+      setError('Google sign in failed');
+    }
+  };
+
+  const handleFacebookSignIn = async () => {
+    try {
+      const cred = await signInWithPopup(auth, facebookProvider);
+      const userData = {
+        email: cred.user.email,
+        uid: cred.user.uid,
+        displayName: cred.user.displayName
+      };
+      localStorage.setItem('user', JSON.stringify(userData));
+      setUser(userData);
+      setIsAuthenticated(true);
+      navigate('/');
+    } catch (err) {
+      setError('Facebook sign in failed');
+    }
+  };
+
   return (
-    <div className="login-container">
+    <div
+      className="auth-modal relative bg-white p-6 rounded shadow-md w-full"
+      style={{ maxWidth: '600px', width: '90%' }}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+      >
+        ✕
+      </button>
       <form onSubmit={handleSubmit} className="login-form">
         <h2>Login</h2>
         {error && <div className="error">{error}</div>}
         <div className="form-group">
-          <label>Username:</label>
+          <label>Email:</label>
           <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             required
           />
         </div>
@@ -41,8 +97,34 @@ function Login() {
             required
           />
         </div>
-        <button type="submit">Login</button>
+        <p className="text-right text-sm">
+          <a href="/forgot-password" className="text-blue-600 underline">Forgot password?</a>
+        </p>
+        <button type="submit" className="auth-button">Login</button>
       </form>
+      <div className="social-auth mt-4">
+        <button onClick={handleGoogleSignIn} className="social-button google-button">
+          <i className="fab fa-google"></i>
+          Continue with Google
+        </button>
+        <button onClick={handleFacebookSignIn} className="social-button facebook-button">
+          <i className="fab fa-facebook"></i>
+          Continue with Facebook
+        </button>
+      </div>
+      <p className="auth-switch mt-4">
+        Don't have an account?{' '}
+        <button
+          type="button"
+          onClick={() => {
+            onClose();
+            onSwitchToSignup && onSwitchToSignup();
+          }}
+          className="text-blue-600 underline"
+        >
+          Sign Up
+        </button>
+      </p>
     </div>
   );
 }

--- a/src/pages/Services.css
+++ b/src/pages/Services.css
@@ -101,7 +101,8 @@
 .service-card {
   background: white;
   border-radius: 12px;
-  padding: 2rem;
+  padding: 0;
+  overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   transition: transform 0.3s ease;
 }
@@ -110,10 +111,31 @@
   transform: translateY(-5px);
 }
 
+.service-rating {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.service-rating .fa-star {
+  color: #fbbf24;
+}
+
+.service-image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+}
+
+.service-content {
+  padding: 1.5rem;
+}
+
 .service-icon {
   font-size: 2.5rem;
   color: #3498db;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
   text-align: center;
 }
 
@@ -218,11 +240,19 @@
   }
 
   .service-card {
-    padding: 1.5rem;
+    padding: 0;
+  }
+
+  .service-content {
+    padding: 1rem;
   }
 
   .service-icon {
     font-size: 2rem;
+  }
+
+  .service-image {
+    height: 140px;
   }
 
   .service-card h3 {

--- a/src/pages/Services.js
+++ b/src/pages/Services.js
@@ -9,6 +9,8 @@ const Services = () => {
       title: 'Plumbing Services',
       description: 'Professional plumbing repairs and installations',
       icon: '🚰',
+      image: 'https://source.unsplash.com/featured/?plumbing',
+      rating: 4.5,
       category: 'Plumbing',
       tags: ['Repairs', 'Installation', 'Maintenance', 'Emergency']
     },
@@ -17,6 +19,8 @@ const Services = () => {
       title: 'Electrical Work',
       description: 'Expert electrical services for your home and office',
       icon: '⚡',
+      image: 'https://source.unsplash.com/featured/?electrician',
+      rating: 4.0,
       category: 'Electrical',
       tags: ['Wiring', 'Installation', 'Repairs', 'Safety']
     },
@@ -25,6 +29,8 @@ const Services = () => {
       title: 'Food Catering',
       description: 'Delicious catering services for all occasions',
       icon: '👨‍🍳',
+      image: 'https://source.unsplash.com/featured/?catering',
+      rating: 4.7,
       category: 'Food',
       tags: ['Catering', 'Events', 'Private Chef', 'Parties']
     },
@@ -33,6 +39,8 @@ const Services = () => {
       title: 'Home Painting',
       description: 'Professional painting services for interior and exterior',
       icon: '🎨',
+      image: 'https://source.unsplash.com/featured/?painting',
+      rating: 4.2,
       category: 'Painting',
       tags: ['Interior', 'Exterior', 'Commercial', 'Residential']
     },
@@ -41,6 +49,8 @@ const Services = () => {
       title: 'Transport Services',
       description: 'Reliable transportation and logistics solutions',
       icon: '🚗',
+      image: 'https://source.unsplash.com/featured/?transport',
+      rating: 4.1,
       category: 'Transport',
       tags: ['Delivery', 'Moving', 'Logistics', 'Transport']
     },
@@ -49,6 +59,8 @@ const Services = () => {
       title: 'Home Cleaning',
       description: 'Thorough home and office cleaning services',
       icon: '🧹',
+      image: 'https://source.unsplash.com/featured/?cleaning',
+      rating: 4.3,
       category: 'Cleaning',
       tags: ['Deep Clean', 'Regular', 'Commercial', 'Residential']
     },
@@ -57,6 +69,8 @@ const Services = () => {
       title: 'Gardening & Lawn',
       description: 'Professional garden maintenance and landscaping',
       icon: '🌿',
+      image: 'https://source.unsplash.com/featured/?gardening',
+      rating: 4.6,
       category: 'Gardening',
       tags: ['Maintenance', 'Landscaping', 'Design', 'Care']
     },
@@ -65,6 +79,8 @@ const Services = () => {
       title: 'Home Repair',
       description: 'General home repairs and maintenance services',
       icon: '🔧',
+      image: 'https://source.unsplash.com/featured/?home%20repair',
+      rating: 4.4,
       category: 'Repair',
       tags: ['Maintenance', 'Repairs', 'Installation', 'Renovation']
     },
@@ -73,6 +89,8 @@ const Services = () => {
       title: 'Locksmith Services',
       description: 'Professional locksmith services for all your security needs',
       icon: '🔐',
+      image: 'https://source.unsplash.com/featured/?locksmith',
+      rating: 4.1,
       category: 'Security',
       tags: ['Emergency', 'Lockout', 'Key Duplication', 'Security']
     },
@@ -81,6 +99,8 @@ const Services = () => {
       title: 'Online Courses',
       description: 'Comprehensive online learning for various skills and subjects',
       icon: '🎓',
+      image: 'https://source.unsplash.com/featured/?online%20course',
+      rating: 4.5,
       category: 'Education',
       tags: ['E-learning', 'Certification', 'Workshops', 'Tutorials']
     },
@@ -89,6 +109,8 @@ const Services = () => {
       title: 'Food Delivery',
       description: 'Fast and reliable food delivery from your favorite restaurants',
       icon: '🍔',
+      image: 'https://source.unsplash.com/featured/?food%20delivery',
+      rating: 4.2,
       category: 'Food',
       tags: ['Delivery', 'Takeout', 'Meal Kits', 'Groceries']
     }
@@ -160,21 +182,45 @@ const Services = () => {
       </div>
 
       <div className="services-grid">
-        {filteredServices.map(service => (
+        {filteredServices.map((service) => (
           <div
             key={service.id}
             className="service-card"
             onClick={() => handleServiceClick(service.id)}
           >
-            <div className="service-icon">{service.icon}</div>
-            <h3>{service.title}</h3>
-            <p>{service.description}</p>
-            <div className="service-meta">
-              <span className="service-category">{service.category}</span>
-              <div className="service-tags">
-                {service.tags.map((tag, index) => (
-                  <span key={index} className="service-tag">{tag}</span>
+            <img
+              src={service.image}
+              alt={service.title}
+              className="service-image"
+            />
+            <div className="service-content">
+              <div className="service-icon">{service.icon}</div>
+              <h3>{service.title}</h3>
+              <div className="service-rating">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <i
+                    key={i}
+                    className={`fas fa-star${
+                      i < Math.round(service.rating)
+                        ? ''
+                        : ' text-gray-300'
+                    }`}
+                  ></i>
                 ))}
+                <span className="ml-1 text-sm text-gray-600">
+                  {service.rating.toFixed(1)}
+                </span>
+              </div>
+              <p>{service.description}</p>
+              <div className="service-meta">
+                <span className="service-category">{service.category}</span>
+                <div className="service-tags">
+                  {service.tags.map((tag, index) => (
+                    <span key={index} className="service-tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/Signup.js
+++ b/src/pages/Signup.js
@@ -5,7 +5,19 @@ import { auth, googleProvider, facebookProvider } from '../firebase';
 import { createUserWithEmailAndPassword, updateProfile, signInWithPopup } from 'firebase/auth';
 import './Auth.css';
 
+const cities = [
+  'Karachi',
+  'Lahore',
+  'Islamabad',
+  'Rawalpindi',
+  'Faisalabad',
+  'Multan',
+  'Peshawar',
+  'Quetta'
+];
+
 const Signup = ({ onClose, onSwitchToLogin }) => {
+  const [method, setMethod] = useState(null); // null, 'email'
   const [step, setStep] = useState(1);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -33,7 +45,7 @@ const Signup = ({ onClose, onSwitchToLogin }) => {
     setPasswordStrength(evaluatePasswordStrength(val));
   };
 
-  const handleSubmit = async (e) => {
+  const handleNext = async (e) => {
     e.preventDefault();
     setError('');
 
@@ -97,8 +109,37 @@ const Signup = ({ onClose, onSwitchToLogin }) => {
       </button>
       <div className="auth-box">
         <h2>Sign Up</h2>
-        <form onSubmit={handleSubmit} className="auth-form">
-          {error && <div className="error-message">{error}</div>}
+        {method === 'email' && (
+          <div className="progress-container">
+            <div
+              className="progress-bar"
+              style={{ width: `${(step / 3) * 100}%` }}
+            ></div>
+          </div>
+        )}
+        {error && <div className="error-message">{error}</div>}
+        {!method && (
+          <div className="social-auth">
+            <button onClick={handleGoogleSignIn} className="social-button google-button">
+              <i className="fab fa-google"></i>
+              Continue with Google
+            </button>
+            <button onClick={handleFacebookSignIn} className="social-button facebook-button">
+              <i className="fab fa-facebook"></i>
+              Continue with Facebook
+            </button>
+            <button
+              type="button"
+              className="social-button"
+              onClick={() => setMethod('email')}
+            >
+              <i className="fas fa-envelope"></i>
+              Continue with Email
+            </button>
+          </div>
+        )}
+        {method === 'email' && (
+          <form onSubmit={handleNext} className="auth-form mt-4">
 
           {step === 1 && (
             <>
@@ -163,10 +204,16 @@ const Signup = ({ onClose, onSwitchToLogin }) => {
               <input
                 type="text"
                 id="address"
+                list="city-list"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
                 required
               />
+              <datalist id="city-list">
+                {cities.map((c) => (
+                  <option key={c} value={c} />
+                ))}
+              </datalist>
             </div>
           )}
 
@@ -174,16 +221,6 @@ const Signup = ({ onClose, onSwitchToLogin }) => {
             {step < 3 ? 'Continue' : 'Sign Up'}
           </button>
         </form>
-        <div className="social-auth mt-4">
-          <button onClick={handleGoogleSignIn} className="social-button google-button">
-            <i className="fab fa-google"></i>
-            Continue with Google
-          </button>
-          <button onClick={handleFacebookSignIn} className="social-button facebook-button">
-            <i className="fab fa-facebook"></i>
-            Continue with Facebook
-          </button>
-        </div>
         <p className="auth-switch mt-4">
           Already have an account?{' '}
           <button
@@ -197,6 +234,7 @@ const Signup = ({ onClose, onSwitchToLogin }) => {
             Login
           </button>
         </p>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Signup.js
+++ b/src/pages/Signup.js
@@ -1,32 +1,59 @@
 import React, { useState, useContext } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../App';
-import { auth } from '../firebase';
-import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
+import { auth, googleProvider, facebookProvider } from '../firebase';
+import { createUserWithEmailAndPassword, updateProfile, signInWithPopup } from 'firebase/auth';
 import './Auth.css';
 
-const Signup = () => {
+const Signup = ({ onClose, onSwitchToLogin }) => {
+  const [step, setStep] = useState(1);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [name, setName] = useState('');
+  const [passwordStrength, setPasswordStrength] = useState('');
+  const [address, setAddress] = useState('');
   const [error, setError] = useState('');
   const { setIsAuthenticated, setUser } = useContext(AuthContext);
   const navigate = useNavigate();
+
+  const evaluatePasswordStrength = (pwd) => {
+    let strength = 'Weak';
+    if (pwd.length >= 8 && /[A-Z]/.test(pwd) && /[0-9]/.test(pwd) && /[^A-Za-z0-9]/.test(pwd)) {
+      strength = 'Strong';
+    } else if (pwd.length >= 6) {
+      strength = 'Moderate';
+    }
+    return strength;
+  };
+
+  const handlePasswordChange = (e) => {
+    const val = e.target.value;
+    setPassword(val);
+    setPasswordStrength(evaluatePasswordStrength(val));
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
 
+    if (step < 3) {
+      setStep(step + 1);
+      return;
+    }
+
     try {
+      const displayName = `${firstName} ${lastName}`.trim();
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-      await updateProfile(userCredential.user, { displayName: name });
-      
+      await updateProfile(userCredential.user, { displayName });
+
       const userData = {
         email: userCredential.user.email,
         uid: userCredential.user.uid,
-        displayName: name
+        displayName,
+        address
       };
-      
+
       localStorage.setItem('user', JSON.stringify(userData));
       setUser(userData);
       setIsAuthenticated(true);
@@ -36,47 +63,139 @@ const Signup = () => {
     }
   };
 
+  const handleGoogleSignIn = async () => {
+    try {
+      await signInWithPopup(auth, googleProvider);
+      navigate('/');
+      setIsAuthenticated(true);
+    } catch (error) {
+      setError('Error with Google sign in');
+    }
+  };
+
+  const handleFacebookSignIn = async () => {
+    try {
+      await signInWithPopup(auth, facebookProvider);
+      navigate('/');
+      setIsAuthenticated(true);
+    } catch (error) {
+      setError('Error with Facebook sign in');
+    }
+  };
+
   return (
-    <div className="auth-container">
+    <div
+      className="auth-container relative bg-white p-6 rounded shadow-md w-full"
+      style={{ maxWidth: '600px', width: '90%' }}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+      >
+        ✕
+      </button>
       <div className="auth-box">
         <h2>Sign Up</h2>
         <form onSubmit={handleSubmit} className="auth-form">
           {error && <div className="error-message">{error}</div>}
-          }
-          <div className="form-group">
-            <label htmlFor="name">Full Name</label>
-            <input
-              type="text"
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor="email">Email</label>
-            <input
-              type="email"
-              id="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor="password">Password</label>
-            <input
-              type="password"
-              id="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          <button type="submit" className="auth-button">Sign Up</button>
+
+          {step === 1 && (
+            <>
+              <div className="form-group">
+                <label htmlFor="firstName">First Name</label>
+                <input
+                  type="text"
+                  id="firstName"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="lastName">Last Name</label>
+                <input
+                  type="text"
+                  id="lastName"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  required
+                />
+              </div>
+            </>
+          )}
+
+          {step === 2 && (
+            <>
+              <div className="form-group">
+                <label htmlFor="email">Email</label>
+                <input
+                  type="email"
+                  id="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="password">Password</label>
+                <input
+                  type="password"
+                  id="password"
+                  value={password}
+                  onChange={handlePasswordChange}
+                  required
+                />
+                {password && (
+                  <p className="text-sm mt-1">{passwordStrength} password</p>
+                )}
+                <small className="text-gray-500">
+                  Use at least 8 characters with a number, symbol and uppercase
+                  letter for a strong password.
+                </small>
+              </div>
+            </>
+          )}
+
+          {step === 3 && (
+            <div className="form-group">
+              <label htmlFor="address">Address</label>
+              <input
+                type="text"
+                id="address"
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                required
+              />
+            </div>
+          )}
+
+          <button type="submit" className="auth-button">
+            {step < 3 ? 'Continue' : 'Sign Up'}
+          </button>
         </form>
-        <p className="auth-switch">
-          Already have an account? <Link to="/login">Login</Link>
+        <div className="social-auth mt-4">
+          <button onClick={handleGoogleSignIn} className="social-button google-button">
+            <i className="fab fa-google"></i>
+            Continue with Google
+          </button>
+          <button onClick={handleFacebookSignIn} className="social-button facebook-button">
+            <i className="fab fa-facebook"></i>
+            Continue with Facebook
+          </button>
+        </div>
+        <p className="auth-switch mt-4">
+          Already have an account?{' '}
+          <button
+            type="button"
+            onClick={() => {
+              onClose();
+              onSwitchToLogin && onSwitchToLogin();
+            }}
+            className="text-blue-600 underline"
+          >
+            Login
+          </button>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create modal-style login and signup forms that can be opened from the header
- hook login and signup buttons in header to open modals instead of navigating
- minor style adjustments with close buttons
- refine login popup layout and add forgot-password link
- implement a responsive AAA-themed footer similar to Yelp's design
- fix build warnings from href placeholders and add missing babel plugin
- add dropdown of Pakistani cities in footer
- implement mobile-friendly Yelp-style header with search and menu overlays

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841c64502408332abe21d03451649dd